### PR TITLE
Updated date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [2018] [Mandar Chandrakant Thorat]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Here is my finding on the external components which are in compliant or non-compliant with the template as of the README in doc/contribute/code_component_README.

ext component | Path | Comments
-- | -- | --
st|ext/hal/st/stm32cube/stm32f1xx/README|Compliant
st|ext/hal/st/stm32cube/stm32f4xx/README	|Compliant
st|ext/hal/st/stm32cube/stm32f7xx/README|Compliant
st|ext/hal/st/stm32cube/stm32f0xx/README	|Compliant
st|ext/hal/st/stm32cube/stm32f3xx/README|Compliant
st|ext/hal/st/stm32cube/stm32l0xx/README|Compliant
st|ext/hal/st/stm32cube/stm32l4xx/README|Compliant
st|ext/hal/st/lib/sensor/vl53l0x/README|Compliant
ti|ext/hal/ti/simplelink/README|Non-compliant
cmsis|ext/hal/cmsis/README|Non-compliant
silabs|ext/hal/silabs/gecko/README|Non-compliant
qmsi|ext/hal/qmsi/README|Non-compliant
nordic|ext/hal/nordic/nrfx/README|Compliant
nordic|ext/hal/nordic/drivers/README.md|Non-compliant
altera|ext/hal/altera/README|Compliant
nxp|ext/hal/nxp/mcux/README|Compliant
nxp|ext/hal/nxp/imx/README|Compliant
atmel|ext/hal/atmel/asf/common/components/wifi/README|Compliant
esp|ext/hal/esp|NoREADME file
fat|ext/fs/fat/README|Non-compliant
nffs|ext/fs/nffs/README.md|Non-compliant
tinycbor|ext/lib/encoding/tinycbor/README|Non-compliant
tinycrypt|ext/lib/crypto/tinycrypt/README|Non-compliant
mbedtls|ext/lib/crypto/mbedtls/README|Non-compliant
mcumgr|ext/lib/mgmt/mcumgr/README.md|Non-compliant
openamp|ext/lib/ipc/README.open-amp|Compliant
libmetal|etx/lib/ipc/README.libmetal|Compliant

